### PR TITLE
minor fix to be work with current clack/lack

### DIFF
--- a/clack.handler.hunchensocket.asd
+++ b/clack.handler.hunchensocket.asd
@@ -6,6 +6,7 @@
   :license "LLGPLv3"
   :depends-on (#:hunchensocket
                #:clack
+               #:lack-component
                #:alexandria
 	       #:split-sequence)
   :serial t

--- a/package.lisp
+++ b/package.lisp
@@ -7,7 +7,7 @@
 	#:split-sequence)
   (:shadow :stop
 	   #:handle-request)
-  (:import-from :clack.component
+  (:import-from :lack.component
 		#:call)
   (:import-from :flexi-streams
 		#:make-external-format


### PR DESCRIPTION
`clack.component` has moved to `lack.component` (if I understand the setup correctly, it is also in `clack-v1-compat` which I'm guessing should disfavored to current clack/lack). I've added the dependency for `lack.component` and fixed the `import-from` for `call`. At least it loads with `quicklisp:quickload` now, but have not tested beyond that.
